### PR TITLE
Add additional tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Ensure cargo.lock file is in sync
+      run: cargo --locked
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
     - name: Lint
-      run: cargo clippy
+      run: cargo clippy && cargo fmt

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -23,6 +23,18 @@ impl ConfigurationFile {
         self == &ConfigurationFile::default()
     }
 
+    pub fn from_str(string: String) -> Result<ConfigurationFile, ConfigureError> {
+        match serde_json::from_str(&string) {
+            Ok(configuration) => return Ok(configuration),
+            Err(_) => return Err(ConfigureError::ConfigureFileNotValid),
+        }
+    }
+
+    pub fn to_string(&self) -> Result<String, ConfigureError> {
+        let string = serde_json::to_string_pretty(&self).unwrap();
+        Ok(string)
+    }
+
     fn needs_project_name(&self) -> bool {
         self.project_name == ""
     }
@@ -65,6 +77,9 @@ pub enum ConfigureError {
     #[error("The .configure file is missing or could not be read")]
     ConfigureFileNotReadable,
 
+   #[error("The .configure file could not be written")]
+    ConfigureFileNotWritable,
+
     #[error("Unable to parse configuration file – the JSON is probably invalid")]
     ConfigureFileNotValid,
 
@@ -75,10 +90,16 @@ pub enum ConfigureError {
     EncryptedFileMissing,
 
     #[error("Unable to read keys.json file in your secrets repo")]
-    KeysFileCannotBeRead,
+    KeysFileNotReadable,
+
+    #[error("Unable to write keys.json file in your secrets repo")]
+    KeysFileNotWritable,
 
     #[error("keys.json file in your secrets repo is not valid – it might be invalid JSON, or it could be structured incorrectly")]
     KeysFileIsNotValid,
+
+    #[error("Attempted to save invalid keys.json data")]
+    KeysDataIsNotValid,
 
     #[error("That project key is not defined in keys.json")]
     MissingProjectKey,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -11,19 +11,19 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct ConfigurationFile {
+pub struct Configuration {
     pub project_name: String,
     pub branch: String,
     pub pinned_hash: String,
     pub files_to_copy: Vec<File>,
 }
 
-impl ConfigurationFile {
+impl Configuration {
     pub fn is_empty(&self) -> bool {
-        self == &ConfigurationFile::default()
+        self == &Configuration::default()
     }
 
-    pub fn from_str(string: String) -> Result<ConfigurationFile, ConfigureError> {
+    pub fn from_str(string: String) -> Result<Configuration, ConfigureError> {
         match serde_json::from_str(&string) {
             Ok(configuration) => return Ok(configuration),
             Err(_) => return Err(ConfigureError::ConfigureFileNotValid),
@@ -50,10 +50,10 @@ impl ConfigurationFile {
     }
 }
 
-impl Default for ConfigurationFile {
+impl Default for Configuration {
     fn default() -> Self {
         let files_to_copy: Vec<File> = Vec::new();
-        ConfigurationFile {
+        Configuration {
             project_name: "".to_string(),
             branch: "".to_string(),
             pinned_hash: "".to_string(),
@@ -148,7 +148,7 @@ impl File {
     }
 }
 
-pub fn apply_configuration(configuration: &ConfigurationFile) {
+pub fn apply_configuration(configuration: &Configuration) {
     // Decrypt the project's configuration files
     decrypt_files_for_configuration(&configuration).expect("Unable to decrypt and copy files");
 
@@ -158,9 +158,9 @@ pub fn apply_configuration(configuration: &ConfigurationFile) {
 }
 
 pub fn update_configuration(
-    mut configuration: ConfigurationFile,
+    mut configuration: Configuration,
     interactive: bool,
-) -> ConfigurationFile {
+) -> Configuration {
     let starting_branch =
         get_current_secrets_branch().expect("Unable to determine current mobile secrets branch");
     let starting_ref =
@@ -284,11 +284,11 @@ pub fn update_configuration(
     configuration
 }
 
-pub fn validate_configuration(configuration: ConfigurationFile) {
+pub fn validate_configuration(configuration: Configuration) {
     println!("{:?}", configuration);
 }
 
-pub fn setup_configuration(mut configuration: ConfigurationFile) {
+pub fn setup_configuration(mut configuration: Configuration) {
     heading("Configure Setup");
     println!("Let's get configuration set up for this project.");
     newline();
@@ -314,7 +314,7 @@ pub fn setup_configuration(mut configuration: ConfigurationFile) {
         .expect("Unable to generate an encryption key for this project");
 }
 
-fn prompt_for_project_name_if_needed(mut configuration: ConfigurationFile) -> ConfigurationFile {
+fn prompt_for_project_name_if_needed(mut configuration: Configuration) -> Configuration {
     // If there's already a project name, don't bother updating it
     if !configuration.needs_project_name() {
         return configuration;
@@ -327,7 +327,7 @@ fn prompt_for_project_name_if_needed(mut configuration: ConfigurationFile) -> Co
     configuration
 }
 
-fn prompt_for_branch(mut configuration: ConfigurationFile, force: bool) -> ConfigurationFile {
+fn prompt_for_branch(mut configuration: Configuration, force: bool) -> Configuration {
     // If there's already a branch set, don't bother updating it
     if !configuration.needs_branch() && !force {
         return configuration;
@@ -355,7 +355,7 @@ fn prompt_for_branch(mut configuration: ConfigurationFile, force: bool) -> Confi
     configuration
 }
 
-fn set_latest_hash_if_needed(mut configuration: ConfigurationFile) -> ConfigurationFile {
+fn set_latest_hash_if_needed(mut configuration: Configuration) -> Configuration {
     if !configuration.needs_pinned_hash() {
         return configuration;
     }
@@ -367,7 +367,7 @@ fn set_latest_hash_if_needed(mut configuration: ConfigurationFile) -> Configurat
     configuration
 }
 
-fn prompt_to_add_files(mut configuration: ConfigurationFile) -> ConfigurationFile {
+fn prompt_to_add_files(mut configuration: Configuration) -> Configuration {
     let mut files = configuration.files_to_copy;
 
     let mut message = "Would you like to add files?";
@@ -419,7 +419,7 @@ fn prompt_to_add_file() -> Option<File> {
 }
 
 fn configure_file_distance_behind_secrets_repo(
-    configuration: &ConfigurationFile,
+    configuration: &Configuration,
     branch_name: &str,
 ) -> i32 {
     debug!("Checking if configure file is behind secrets repo");

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -33,7 +33,7 @@ impl Configuration {
     pub fn to_string(&self) -> Result<String, ConfigureError> {
         match serde_json::to_string_pretty(&self) {
             Ok(string) => Ok(string),
-            Err(_) => Err(ConfigureError::ConfigureDataNotValid)
+            Err(_) => Err(ConfigureError::ConfigureDataNotValid),
         }
     }
 
@@ -79,7 +79,7 @@ pub enum ConfigureError {
     #[error("The .configure file is missing or could not be read")]
     ConfigureFileNotReadable,
 
-   #[error("The .configure file could not be written")]
+    #[error("The .configure file could not be written")]
     ConfigureFileNotWritable,
 
     #[error("Unable to parse configuration file – the JSON is probably invalid")]
@@ -131,17 +131,14 @@ impl File {
     }
 
     fn get_backup_destination_for_date(&self, date: DateTime<Utc>) -> PathBuf {
-
         let path = Path::new(&self.destination);
 
-        let directory = path
-            .parent()
-            .unwrap_or(Path::new("/")); // If we're at the root of the file system
+        let directory = path.parent().unwrap_or_else(|| Path::new("/")); // If we're at the root of the file system
 
         let file_stem = path
             .file_stem()
-            .unwrap_or_default()  // Ensure one exists
-            .to_str()             // Convert from OsStr
+            .unwrap_or_default() // Ensure one exists
+            .to_str() // Convert from OsStr
             .unwrap_or_default(); // Blank on failure
 
         let extension = path
@@ -150,9 +147,7 @@ impl File {
             .to_str()
             .unwrap_or_default();
 
-        let datetime = date
-            .format("%Y-%m-%d-%H-%M-%S")
-            .to_string();
+        let datetime = date.format("%Y-%m-%d-%H-%M-%S").to_string();
 
         let filename: String;
 
@@ -162,7 +157,7 @@ impl File {
             filename = format!("{:}-{:}.{:}.bak", file_stem, datetime, extension);
         }
 
-        return directory.join(filename)
+        directory.join(filename)
     }
 }
 
@@ -175,10 +170,7 @@ pub fn apply_configuration(configuration: &Configuration) {
     info!("Done")
 }
 
-pub fn update_configuration(
-    mut configuration: Configuration,
-    interactive: bool,
-) -> Configuration {
+pub fn update_configuration(mut configuration: Configuration, interactive: bool) -> Configuration {
     let starting_branch =
         get_current_secrets_branch().expect("Unable to determine current mobile secrets branch");
     let starting_ref =
@@ -499,32 +491,58 @@ mod tests {
 
     #[test]
     fn test_that_get_encrypted_destination_ends_in_enc_extension() {
-        let file = File { source: "".to_string(), destination: ".configure-files/file".to_string() };
-        assert_eq!(file.get_encrypted_destination(), ".configure-files/file.enc")
+        let file = File {
+            source: "".to_string(),
+            destination: ".configure-files/file".to_string(),
+        };
+        assert_eq!(
+            file.get_encrypted_destination(),
+            ".configure-files/file.enc"
+        )
     }
 
     #[test]
     fn test_that_get_decrypted_destination_matches_starting_filename() {
-        let file = File { source: "".to_string(), destination: ".configure-files/file".to_string() };
+        let file = File {
+            source: "".to_string(),
+            destination: ".configure-files/file".to_string(),
+        };
         assert_eq!(file.get_decrypted_destination(), ".configure-files/file")
     }
 
     #[test]
     fn test_that_get_backup_destination_has_bak_extension() {
-        let file = File { source: "".to_string(), destination: ".configure-files/file".to_string() };
+        let file = File {
+            source: "".to_string(),
+            destination: ".configure-files/file".to_string(),
+        };
         assert_eq!(file.get_backup_destination().extension().unwrap(), "bak")
     }
 
     #[test]
     fn test_that_get_backup_destination_works_for_files_in_filesystem_root() {
-        let file = File { source: "".to_string(), destination: "/.configure-files/file.txt".to_string() };
-        assert_eq!(file.get_backup_destination_for_date(get_zero_date()).to_str(), Some("/.configure-files/file-1970-01-01-00-00-00.txt.bak"))
+        let file = File {
+            source: "".to_string(),
+            destination: "/.configure-files/file.txt".to_string(),
+        };
+        assert_eq!(
+            file.get_backup_destination_for_date(get_zero_date())
+                .to_str(),
+            Some("/.configure-files/file-1970-01-01-00-00-00.txt.bak")
+        )
     }
 
     #[test]
     fn test_that_get_backup_destination_works_for_files_without_extension() {
-        let file = File { source: "".to_string(), destination: ".configure-files/file".to_string() };
-        assert_eq!(file.get_backup_destination_for_date(get_zero_date()).to_str(), Some(".configure-files/file-1970-01-01-00-00-00.bak"))
+        let file = File {
+            source: "".to_string(),
+            destination: ".configure-files/file".to_string(),
+        };
+        assert_eq!(
+            file.get_backup_destination_for_date(get_zero_date())
+                .to_str(),
+            Some(".configure-files/file-1970-01-01-00-00-00.bak")
+        )
     }
 
     fn get_zero_date() -> DateTime<Utc> {

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -526,9 +526,8 @@ mod tests {
             destination: "/.configure-files/file.txt".to_string(),
         };
         assert_eq!(
-            file.get_backup_destination_for_date(get_zero_date())
-                .to_str(),
-            Some("/.configure-files/file-1970-01-01-00-00-00.txt.bak")
+            file.get_backup_destination_for_date(get_zero_date()),
+            Path::new("/.configure-files").join("file-1970-01-01-00-00-00.txt.bak")
         )
     }
 
@@ -539,9 +538,8 @@ mod tests {
             destination: ".configure-files/file".to_string(),
         };
         assert_eq!(
-            file.get_backup_destination_for_date(get_zero_date())
-                .to_str(),
-            Some(".configure-files/file-1970-01-01-00-00-00.bak")
+            file.get_backup_destination_for_date(get_zero_date()),
+            Path::new(".configure-files").join("file-1970-01-01-00-00-00.bak")
         )
     }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -31,8 +31,10 @@ impl ConfigurationFile {
     }
 
     pub fn to_string(&self) -> Result<String, ConfigureError> {
-        let string = serde_json::to_string_pretty(&self).unwrap();
-        Ok(string)
+        match serde_json::to_string_pretty(&self) {
+            Ok(string) => return Ok(string),
+            Err(_) => return Err(ConfigureError::ConfigureDataNotValid)
+        }
     }
 
     fn needs_project_name(&self) -> bool {
@@ -83,6 +85,9 @@ pub enum ConfigureError {
     #[error("Unable to parse configuration file – the JSON is probably invalid")]
     ConfigureFileNotValid,
 
+    #[error("Unable to save an configuration data – it couldn't be converted to JSON")]
+    ConfigureDataNotValid,
+
     #[error("No secrets repository could be found on this machine")]
     SecretsNotPresent,
 
@@ -98,7 +103,7 @@ pub enum ConfigureError {
     #[error("keys.json file in your secrets repo is not valid – it might be invalid JSON, or it could be structured incorrectly")]
     KeysFileIsNotValid,
 
-    #[error("Attempted to save invalid keys.json data")]
+    #[error("Attempted to save invalid keys.json data – it couldn't be converted to JSON")]
     KeysDataIsNotValid,
 
     #[error("That project key is not defined in keys.json")]

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -447,8 +447,38 @@ fn configure_file_distance_behind_secrets_repo(
 #[cfg(test)]
 mod tests {
     // Import the parent scope
-    //use super::*;
+    use super::*;
     //use crate::SECRETS_KEY_NAME;
+
+    #[test]
+    fn test_that_default_configuration_needs_project_name() {
+        assert!(Configuration::default().needs_project_name())
+    }
+
+    #[test]
+    fn test_that_default_configuration_needs_branch() {
+        assert!(Configuration::default().needs_branch())
+    }
+
+    #[test]
+    fn test_that_default_configuration_needs_pinned_hash() {
+        assert!(Configuration::default().needs_pinned_hash())
+    }
+
+    #[test]
+    fn test_that_invalid_configuration_cannot_be_deseralized() {
+        assert!(Configuration::from_str("".to_string()).is_err())
+    }
+
+    #[test]
+    fn test_that_default_configuration_can_be_serialized() {
+        assert!(Configuration::default().to_string().is_ok())
+    }
+
+    #[test]
+    fn test_that_default_configuration_is_empty() {
+        assert!(Configuration::default().is_empty())
+    }
 
     // #[test]
     // fn test_that_pinned_hash_is_updated_when_running_update_on_empty_file() {

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -62,6 +62,12 @@ pub enum ConfigureError {
     #[error("Unable to find the root of the respository – are you sure you're running this inside a git repo?")]
     ProjectNotPresent,
 
+    #[error("The .configure file is missing or could not be read")]
+    ConfigureFileNotReadable,
+
+    #[error("Unable to parse configuration file – the JSON is probably invalid")]
+    ConfigureFileNotValid,
+
     #[error("No secrets repository could be found on this machine")]
     SecretsNotPresent,
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -59,6 +59,9 @@ pub enum ConfigureError {
     #[error("Invalid git status")]
     GitStatusUnknownError,
 
+    #[error("Unable to find the root of the respository – are you sure you're running this inside a git repo?")]
+    ProjectNotPresent,
+
     #[error("No secrets repository could be found on this machine")]
     SecretsNotPresent,
 
@@ -372,7 +375,7 @@ fn prompt_to_add_file() -> Option<File> {
     let relative_destination_file_path =
         prompt("Enter the destination file path (relative to the project root):");
 
-    let project_root = find_project_root();
+    let project_root = find_project_root().unwrap();
     let full_destination_file_path = project_root.join(&relative_destination_file_path);
 
     debug!("Destination: {:?}", full_destination_file_path);

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -257,7 +257,7 @@ pub fn update_configuration(
     //
     // Step 5 – Write out encrypted files as needed
     //
-    save_configuration(&configuration).expect("Unable to save updated configuration");
+    write_configuration(&configuration).expect("Unable to save updated configuration");
 
     //
     // Step 6 – Write out encrypted files as needed
@@ -307,7 +307,7 @@ pub fn setup_configuration(mut configuration: ConfigurationFile) {
 
     info!("Writing changes to .configure");
 
-    save_configuration(&configuration).expect("Unable to save configure file");
+    write_configuration(&configuration).expect("Unable to save configure file");
 
     // Create a key in `keys.json` for the project if one doesn't already exist
     generate_encryption_key_if_needed(&configuration)

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -25,15 +25,15 @@ impl Configuration {
 
     pub fn from_str(string: String) -> Result<Configuration, ConfigureError> {
         match serde_json::from_str(&string) {
-            Ok(configuration) => return Ok(configuration),
-            Err(_) => return Err(ConfigureError::ConfigureFileNotValid),
+            Ok(configuration) => Ok(configuration),
+            Err(_) => Err(ConfigureError::ConfigureFileNotValid),
         }
     }
 
     pub fn to_string(&self) -> Result<String, ConfigureError> {
         match serde_json::to_string_pretty(&self) {
-            Ok(string) => return Ok(string),
-            Err(_) => return Err(ConfigureError::ConfigureDataNotValid)
+            Ok(string) => Ok(string),
+            Err(_) => Err(ConfigureError::ConfigureDataNotValid)
         }
     }
 
@@ -138,7 +138,7 @@ impl File {
         let datetime = Local::now().format("%Y-%m-%d-%H-%M-%S").to_string();
         let extension = path
             .extension()
-            .unwrap_or(std::ffi::OsStr::new(""))
+            .unwrap_or_default()
             .to_str()
             .unwrap_or("");
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 /// Find the .configure file in the current project
 pub fn find_configure_file() -> PathBuf {
-    let configure_file_path = get_configure_file_path();
+    let configure_file_path = get_configure_file_path().unwrap();
 
     if !configure_file_path.exists() {
         info!(
@@ -30,8 +30,9 @@ pub fn find_configure_file() -> PathBuf {
     configure_file_path
 }
 
-fn get_configure_file_path() -> PathBuf {
-    find_project_root().unwrap().join(".configure")
+fn get_configure_file_path() -> Result<PathBuf, ConfigureError> {
+    let project_root = find_project_root()?;
+    Ok(project_root.join(".configure"))
 }
 
 pub fn find_keys_file() -> Result<PathBuf, ConfigureError> {

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,5 +1,5 @@
 use crate::encryption::{decrypt_file, encrypt_file, generate_key};
-use crate::ConfigurationFile;
+use crate::Configuration;
 use crate::ConfigureError;
 use log::{debug, info};
 use ring::digest::{Context, SHA256};
@@ -21,7 +21,7 @@ pub fn find_configure_file() -> Result<PathBuf, ConfigureError> {
             configure_file_path
         );
 
-        write_configuration_to(&ConfigurationFile::default(), &configure_file_path)?
+        write_configuration_to(&Configuration::default(), &configure_file_path)?
     }
 
     debug!("Configure file found at: {:?}", configure_file_path);
@@ -101,7 +101,7 @@ pub fn find_secrets_repo() -> Result<PathBuf, ConfigureError> {
     Err(crate::configure::ConfigureError::SecretsNotPresent)
 }
 
-pub fn read_configuration() -> Result<ConfigurationFile, ConfigureError> {
+pub fn read_configuration() -> Result<Configuration, ConfigureError> {
     let configure_file_path = find_configure_file()?;
 
     let mut file = match File::open(&configure_file_path) {
@@ -115,16 +115,16 @@ pub fn read_configuration() -> Result<ConfigurationFile, ConfigureError> {
         Err(_) => return Err(ConfigureError::ConfigureFileNotReadable),
     };
 
-    ConfigurationFile::from_str(file_contents)
+    Configuration::from_str(file_contents)
 }
 
-pub fn write_configuration(configuration: &ConfigurationFile) -> Result<(), ConfigureError> {
+pub fn write_configuration(configuration: &Configuration) -> Result<(), ConfigureError> {
     let configuration_file = find_configure_file()?;
     write_configuration_to(configuration, &configuration_file)
 }
 
 fn write_configuration_to(
-    configuration: &ConfigurationFile,
+    configuration: &Configuration,
     configure_file: &PathBuf,
 ) -> Result<(), ConfigureError> {
     let serialized = configuration.to_string()?;
@@ -143,7 +143,7 @@ fn write_configuration_to(
 }
 
 pub fn generate_encryption_key_if_needed(
-    configuration: &ConfigurationFile,
+    configuration: &Configuration,
 ) -> Result<(), ConfigureError> {
     if encryption_key_for_configuration(&configuration).is_ok() {
         return Ok(());
@@ -158,7 +158,7 @@ pub fn generate_encryption_key_if_needed(
 }
 
 pub fn encryption_key_for_configuration(
-    configuration: &ConfigurationFile,
+    configuration: &Configuration,
 ) -> Result<String, ConfigureError> {
     let keys_file_path = find_keys_file()?;
 
@@ -205,7 +205,7 @@ fn save_keys(destination: &PathBuf, keys: &HashMap<String, String>) -> Result<()
 }
 
 pub fn decrypt_files_for_configuration(
-    configuration: &ConfigurationFile,
+    configuration: &Configuration,
 ) -> Result<(), ConfigureError> {
     let project_root = find_project_root()?;
 
@@ -278,7 +278,7 @@ pub fn decrypt_files_for_configuration(
 }
 
 pub fn write_encrypted_files_for_configuration(
-    configuration: &ConfigurationFile,
+    configuration: &Configuration,
     encryption_key: String,
 ) -> Result<(), ConfigureError> {
     let project_root = find_project_root()?;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -58,21 +58,20 @@ pub fn find_project_root() -> Result<PathBuf, ConfigureError> {
 
     let repo = match git2::Repository::discover(&path) {
         Ok(repo) => repo,
-        Err(_) => return Err(ConfigureError::ProjectNotPresent)
+        Err(_) => return Err(ConfigureError::ProjectNotPresent),
     };
 
     debug!("Discovered Repository at {:?}", &path);
 
     let project_root = match repo.workdir() {
         Some(dir) => dir,
-        None => return Err(ConfigureError::ProjectNotPresent)
+        None => return Err(ConfigureError::ProjectNotPresent),
     };
 
     Ok(project_root.to_path_buf())
 }
 
 pub fn find_secrets_repo() -> Result<PathBuf, ConfigureError> {
-
     // Allow developers to specify where they want the secrets repo to be located using an environment variable
     if let Ok(var) = env::var(crate::SECRETS_KEY_NAME) {
         let user_secrets_path = Path::new(&var);
@@ -187,10 +186,9 @@ fn read_keys(source: &PathBuf) -> Result<HashMap<String, String>, ConfigureError
 }
 
 fn save_keys(destination: &PathBuf, keys: &HashMap<String, String>) -> Result<(), ConfigureError> {
-
     let json = match serde_json::to_string_pretty(&keys) {
         Ok(json) => json,
-        Err(_) => return Err(ConfigureError::KeysDataIsNotValid)
+        Err(_) => return Err(ConfigureError::KeysDataIsNotValid),
     };
 
     let mut file = match File::create(destination) {
@@ -349,7 +347,10 @@ mod tests {
 
     #[test]
     fn test_get_configure_file_path_contains_configure_file() {
-        assert_eq!(get_configure_file_path().unwrap().file_name(), Some(OsStr::new(".configure"))) ;
+        assert_eq!(
+            get_configure_file_path().unwrap().file_name(),
+            Some(OsStr::new(".configure"))
+        );
     }
 
     #[test]

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -111,7 +111,7 @@ pub fn read_configuration() -> Result<Configuration, ConfigureError> {
 
     let mut file_contents = String::new();
     match file.read_to_string(&mut file_contents) {
-        Ok(_) => assert!(true), // no-op
+        Ok(_) => (), // no-op
         Err(_) => return Err(ConfigureError::ConfigureFileNotReadable),
     };
 
@@ -137,8 +137,8 @@ fn write_configuration_to(
     };
 
     match file.write_all(serialized.as_bytes()) {
-        Ok(_) => return Ok(()),
-        Err(_) => return Err(ConfigureError::ConfigureFileNotWritable),
+        Ok(_) => Ok(()),
+        Err(_) => Err(ConfigureError::ConfigureFileNotWritable),
     }
 }
 
@@ -168,7 +168,7 @@ pub fn encryption_key_for_configuration(
 
     match keys.get(&configuration.project_name) {
         Some(key) => Ok(key.to_string()),
-        None => return Err(ConfigureError::MissingProjectKey),
+        None => Err(ConfigureError::MissingProjectKey),
     }
 }
 
@@ -199,8 +199,8 @@ fn save_keys(destination: &PathBuf, keys: &HashMap<String, String>) -> Result<()
     };
 
     match file.write_all(json.as_bytes()) {
-        Ok(_) => return Ok(()),
-        Err(_) => return Err(ConfigureError::KeysFileNotWritable),
+        Ok(_) => Ok(()),
+        Err(_) => Err(ConfigureError::KeysFileNotWritable),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,3 +90,4 @@ fn init_encryption() {
 }
 
 const SECRETS_KEY_NAME: &str = "SECRETS_REPO";
+const ENCRYPTION_KEY_NAME: &str = "CONFIGURE_ENCRYPTION_KEY";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@ use log::debug;
 ///
 pub fn init() {
     init_encryption();
-    let configuration = read_configuration()
-        .expect("Unable to read configuration from `.configure` file");
+    let configuration =
+        read_configuration().expect("Unable to read configuration from `.configure` file");
     setup_configuration(configuration);
 }
 
@@ -28,8 +28,8 @@ pub fn init() {
 ///
 pub fn apply(interactive: bool) {
     init_encryption();
-    let configuration = read_configuration()
-        .expect("Unable to read configuration from `.configure` file");
+    let configuration =
+        read_configuration().expect("Unable to read configuration from `.configure` file");
 
     if configuration.is_empty() {
         if interactive {
@@ -53,8 +53,8 @@ pub fn apply(interactive: bool) {
 ///
 pub fn update(interactive: bool) {
     init_encryption();
-    let configuration = read_configuration()
-        .expect("Unable to read configuration from `.configure` file");
+    let configuration =
+        read_configuration().expect("Unable to read configuration from `.configure` file");
 
     if configuration.is_empty() {
         if interactive {
@@ -71,8 +71,8 @@ pub fn update(interactive: bool) {
 ///
 pub fn validate() {
     init_encryption();
-    let configuration = read_configuration()
-        .expect("Unable to read configuration from `.configure` file");
+    let configuration =
+        read_configuration().expect("Unable to read configuration from `.configure` file");
 
     if configuration.is_empty() {
         ui::warn("Unable to validate configuration – it is empty");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@ use log::debug;
 ///
 pub fn init() {
     init_encryption();
-    let configuration = read_configuration();
+    let configuration = read_configuration()
+        .expect("Unable to read configuration from `.configure` file");
     setup_configuration(configuration);
 }
 
@@ -27,7 +28,8 @@ pub fn init() {
 ///
 pub fn apply(interactive: bool) {
     init_encryption();
-    let configuration = read_configuration();
+    let configuration = read_configuration()
+        .expect("Unable to read configuration from `.configure` file");
 
     if configuration.is_empty() {
         if interactive {
@@ -51,7 +53,8 @@ pub fn apply(interactive: bool) {
 ///
 pub fn update(interactive: bool) {
     init_encryption();
-    let configuration = read_configuration();
+    let configuration = read_configuration()
+        .expect("Unable to read configuration from `.configure` file");
 
     if configuration.is_empty() {
         if interactive {
@@ -68,7 +71,8 @@ pub fn update(interactive: bool) {
 ///
 pub fn validate() {
     init_encryption();
-    let configuration = read_configuration();
+    let configuration = read_configuration()
+        .expect("Unable to read configuration from `.configure` file");
 
     if configuration.is_empty() {
         ui::warn("Unable to validate configuration – it is empty");


### PR DESCRIPTION
Adds test coverage to some common actions as well as allowing the use of an environment variable to read the decryption key when running `apply`.