### PR TITLE
Fix a bug in repo status parsing

### DIFF
--- a/src/string.rs
+++ b/src/string.rs
@@ -22,8 +22,7 @@ fn index_of_string_in(string: &str, strings: &[String]) -> Option<i32> {
 
 #[cfg(test)]
 mod tests {
-    use crate::string::distance_between_strings_in;
-    use crate::string::index_of_string_in;
+    use super::*;
 
     #[test]
     fn test_that_index_of_string_in_works() {


### PR DESCRIPTION
Fixes a bug causing the repo status to always be mis-reported as "in sync"