### PR TITLE
Publish to s3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,13 +145,29 @@ jobs:
     needs: [windows,linux,mac]
     steps:
       - uses: actions/checkout@v2
+      - uses: kceb/pull-request-url-action@v1
+        id: pr-url
       - name: Release
         run: |
           cd gradle-plugin
-          ./gradlew bintrayUpload
+
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          BRANCH=${GITHUB_REF#refs/heads/}
+          PULL_REQUEST_URL=${{ steps.pr-url.outputs.url }}
+
+          echo "Environment:"
+          echo "> SHA1: $GITHUB_SHA"
+          echo "> tag?: $TAG_NAME"
+          echo "> branch?: $BRANCH"
+          echo "> PR?: $PULL_REQUEST_URL"
+
+          PARAMS=(--sha1=$GITHUB_SHA)
+          [[ -n "$TAG_NAME" ]] && PARAMS+=(--tag-name=$TAG_NAME)
+          [[ -n "$BRANCH" ]] && PARAMS+=(--branch-name=$BRANCH)
+          [[ -n "$PULL_REQUEST_URL" ]] && PARAMS+=(--pull-request-url=$PULL_REQUEST_URL)
+
+          ./gradlew :configure:publishPluginToS3 "${PARAMS[@]}"
         env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
-
-
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,7 @@ name: Release
 
 on:
   push:
-    branches:
-      - trunk
     tags:
-      - '*'
-    pull_request:
       - '*'
 
 jobs:
@@ -149,28 +145,12 @@ jobs:
     needs: [windows,linux,mac]
     steps:
       - uses: actions/checkout@v2
-      - uses: kceb/pull-request-url-action@v1
-        id: pr-url
       - name: Release
         run: |
           cd gradle-plugin
-
           TAG_NAME=${GITHUB_REF#refs/tags/}
-          BRANCH=${GITHUB_REF#refs/heads/}
-          PULL_REQUEST_URL=${{ steps.pr-url.outputs.url }}
 
-          echo "Environment:"
-          echo "> SHA1: $GITHUB_SHA"
-          echo "> tag?: $TAG_NAME"
-          echo "> branch?: $BRANCH"
-          echo "> PR?: $PULL_REQUEST_URL"
-
-          PARAMS=(--sha1=$GITHUB_SHA)
-          [[ -n "$TAG_NAME" ]] && PARAMS+=(--tag-name=$TAG_NAME)
-          [[ -n "$BRANCH" ]] && PARAMS+=(--branch-name=$BRANCH)
-          [[ -n "$PULL_REQUEST_URL" ]] && PARAMS+=(--pull-request-url=$PULL_REQUEST_URL)
-
-          ./gradlew :configure:publishPluginToS3 "${PARAMS[@]}"
+          ./gradlew :configure:publishPluginToS3 --tag-name=TAG_NAME
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,8 +150,7 @@ jobs:
           cd gradle-plugin
           TAG_NAME=${GITHUB_REF#refs/tags/}
 
-          ./gradlew :configure:publishPluginToS3 --tag-name=TAG_NAME
+          ./gradlew :configure:publishPluginToS3 --tag-name=$TAG_NAME
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,11 @@ name: Release
 
 on:
   push:
+    branches:
+      - trunk
     tags:
+      - '*'
+    pull_request:
       - '*'
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configure"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Jeremy Massel <jeremy.massel@automattic.com>"]
 edition = "2018"
 

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -9,7 +9,7 @@ buildscript {
         maven { url = uri("https://a8c-libs.s3.amazonaws.com/android") }
     }
     dependencies {
-        classpath("com.automattic.android:publish-to-s3:0.3")
+        classpath("com.automattic.android:publish-to-s3:0.3.1")
     }
 }
 
@@ -19,6 +19,10 @@ plugins {
 }
 
 apply(plugin = "com.automattic.android.publish-plugin-to-s3")
+configure<com.automattic.android.publish.PublishPluginToS3Extension> {
+    groupId = "com.automattic"
+    artifactId = "configure"
+}
 
 repositories {
     jcenter()

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -1,28 +1,13 @@
-import com.novoda.gradle.release.PublishExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /// The plugin version number – change this to match whatever your tag will be
 version = "0.5.0"
 group = "com.automattic.android"
 
-buildscript {
-    repositories {
-        jcenter()
-        maven {
-            setUrl("https://plugins.gradle.org/m2/")
-        }
-    }
-    dependencies {
-        classpath("com.novoda", "bintray-release", "0.9.2")
-    }
-}
-
 plugins {
     `kotlin-dsl`
     id("com.github.gmazzo.buildconfig") version "2.0.2"
 }
-
-apply(null, "com.novoda.bintray-release")
 
 repositories {
     jcenter()
@@ -52,22 +37,6 @@ gradlePlugin {
             implementationClass = "com.automattic.android.configure.ConfigurePlugin"
         }
     }
-}
-
-/// Register the plugin's maven configuration for upload
-configure<PublishExtension> {
-    userOrg = "automattic"
-    groupId = "com.automattic.android"
-    artifactId = "configure"
-    publishVersion = "${version}"
-    desc = "A lightweight tool for working with configuration files"
-    website = "https://github.com/automattic/configure"
-
-    dryRun = false
-    autoPublish = true
-
-    bintrayUser = System.getenv("BINTRAY_USER")
-    bintrayKey = System.getenv("BINTRAY_KEY")
 }
 
 /// Set build configuration constants for use at runtime

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -1,9 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-/// The plugin version number – change this to match whatever your tag will be
-version = "0.6.0"
-group = "com.automattic.android"
-
 buildscript {
     repositories {
         maven { url = uri("https://a8c-libs.s3.amazonaws.com/android") }

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 apply(plugin = "com.automattic.android.publish-plugin-to-s3")
 configure<com.automattic.android.publish.PublishPluginToS3Extension> {
-    groupId = "com.automattic"
+    groupId = "com.automattic.android"
     artifactId = "configure"
 }
 

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -4,10 +4,21 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 version = "0.5.0"
 group = "com.automattic.android"
 
+buildscript {
+    repositories {
+        maven { url = uri("https://a8c-libs.s3.amazonaws.com/android") }
+    }
+    dependencies {
+        classpath("com.automattic.android:publish-to-s3:0.3")
+    }
+}
+
 plugins {
     `kotlin-dsl`
     id("com.github.gmazzo.buildconfig") version "2.0.2"
 }
+
+apply(plugin = "com.automattic.android.publish-plugin-to-s3")
 
 repositories {
     jcenter()

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -1,5 +1,9 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+/// The plugin version number – change this to match whatever your tag will be
+group = "com.automattic.android"
+version = "0.5.0"
+
 buildscript {
     repositories {
         maven { url = uri("https://a8c-libs.s3.amazonaws.com/android") }
@@ -11,7 +15,7 @@ buildscript {
 
 plugins {
     `kotlin-dsl`
-    id("com.github.gmazzo.buildconfig") version "2.0.2"
+    id("com.github.gmazzo.buildconfig") version "3.0.0"
 }
 
 apply(plugin = "com.automattic.android.publish-plugin-to-s3")

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /// The plugin version number – change this to match whatever your tag will be
-version = "0.5.0"
+version = "0.6.0"
 group = "com.automattic.android"
 
 buildscript {

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /// The plugin version number – change this to match whatever your tag will be
 group = "com.automattic.android"
-version = "0.5.0"
+version = "0.6.0"
 
 buildscript {
     repositories {

--- a/gradle-plugin/configure/src/main/kotlin/com/automattic/android/configure/ConfigureHelpers.kt
+++ b/gradle-plugin/configure/src/main/kotlin/com/automattic/android/configure/ConfigureHelpers.kt
@@ -8,7 +8,6 @@ import java.net.URL
 import java.nio.file.Path
 import java.nio.file.Paths
 
-
 object ConfigureHelpers {
 
     val configureRootPath: Path = Paths.get(System.getProperty("user.dir")).resolve("vendor").resolve("configure")


### PR DESCRIPTION
This PR updates the Gradle plugin to publish to S3 instead of Bintray. It uses the [publish-to-s3-gradle-plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin) with its latest changes [here](https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/17).

@jkmassel and I have decided to make the switch to the [publish-to-s3-gradle-plugin](https://github.com/Automattic/publish-to-s3-gradle-plugin) incrementally. We'd like to publish the binary as part of the Gradle plugin and remove the [version correctness dance in github action](https://github.com/Automattic/configure/blob/trunk/.github/workflows/release.yml#L21-L39) before we start publishing the plugin for each PR commit and commits on `trunk`. Right now it's only published on tag, which is the same behavior as before.

We decided to review/merge the changes, tag it and then test its usage since it's the fastest feedback loop and won't impact anyone else.