### PR TITLE
Set java compatibility to java 8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configure"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jeremy Massel <jeremy.massel@automattic.com>"]
 edition = "2018"
 

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /// The plugin version number – change this to match whatever your tag will be
 group = "com.automattic.android"
-version = "0.6.0"
+version = "0.6.1"
 
 buildscript {
     repositories {
@@ -26,6 +26,11 @@ configure<com.automattic.android.publish.PublishPluginToS3Extension> {
 
 repositories {
     jcenter()
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 /// Don't allow warnings in the project – this can prevent us from shipping a broken build


### PR DESCRIPTION
Please see https://github.com/Automattic/publish-to-s3-gradle-plugin/pull/18 for details because we had the exact same issue in publish-to-s3 Gradle plugin, but this time it's for configure Gradle plugin and Jitpack.

Since this fix is tested for publish-to-s3 plugin, I have not tested this one. (as it's pretty convoluted to do so) I'll just test it with a new tag and cleanup if there are any issues.