### PR TITLE
Update publish to s3 plugin

### DIFF
--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -4,24 +4,10 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 group = "com.automattic.android"
 version = "0.6.2"
 
-buildscript {
-    repositories {
-        maven { url = uri("https://a8c-libs.s3.amazonaws.com/android") }
-    }
-    dependencies {
-        classpath("com.automattic.android:publish-to-s3:0.4.0")
-    }
-}
-
 plugins {
     `kotlin-dsl`
     id("com.github.gmazzo.buildconfig") version "3.0.0"
-}
-
-apply(plugin = "com.automattic.android.publish-plugin-to-s3")
-configure<com.automattic.android.publish.PublishPluginToS3Extension> {
-    groupId = "com.automattic.android"
-    artifactId = "configure"
+    id("com.automattic.android.publish-to-s3")
 }
 
 repositories {

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 java {

--- a/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle-plugin/gradlew.bat
+++ b/gradle-plugin/gradlew.bat
@@ -29,9 +29,6 @@ if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
-@rem Resolve any "." and ".." in APP_HOME to make it shorter.
-for %%i in ("%APP_HOME%") do set APP_HOME=%%~fi
-
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS="-Xmx64m" "-Xms64m"
 
@@ -40,7 +37,7 @@ if defined JAVA_HOME goto findJavaFromJavaHome
 
 set JAVA_EXE=java.exe
 %JAVA_EXE% -version >NUL 2>&1
-if "%ERRORLEVEL%" == "0" goto execute
+if "%ERRORLEVEL%" == "0" goto init
 
 echo.
 echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
@@ -54,7 +51,7 @@ goto fail
 set JAVA_HOME=%JAVA_HOME:"=%
 set JAVA_EXE=%JAVA_HOME%/bin/java.exe
 
-if exist "%JAVA_EXE%" goto execute
+if exist "%JAVA_EXE%" goto init
 
 echo.
 echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
@@ -64,14 +61,28 @@ echo location of your Java installation.
 
 goto fail
 
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
 :execute
 @rem Setup the command line
 
 set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
 
-
 @rem Execute Gradle
-"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %*
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
 
 :end
 @rem End local scope for the variables with windows NT shell

--- a/gradle-plugin/settings.gradle
+++ b/gradle-plugin/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+    plugins {
+        id "com.automattic.android.publish-to-s3" version "0.7.0"
+    }
+    repositories {
+        maven {
+            url 'https://a8c-libs.s3.amazonaws.com/android'
+            content {
+                includeGroup "com.automattic.android"
+                includeGroup "com.automattic.android.publish-to-s3"
+            }
+        }
+        gradlePluginPortal()
+    }
+}
+
 include "configure"


### PR DESCRIPTION
This PR updates `publish-to-s3` Gradle plugin with the latest version `0.7.0`, using plugin DSL syntax. It also updates Gradle to `7.4.1` and replaces `jcenter` with `mavenCentral`.