### PR TITLE
Adds java-gradle-plugin

### DIFF
--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -6,6 +6,7 @@ version = "0.6.2"
 
 plugins {
     `kotlin-dsl`
+    id("java-gradle-plugin")
     id("com.github.gmazzo.buildconfig") version "3.0.0"
     id("com.automattic.android.publish-to-s3")
 }


### PR DESCRIPTION
This plugin is necessary to be able to publish the plugin marker which is necessary for the plugin to be added with plugin DSL syntax.