### PR TITLE
Use older ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
         matrix:
-          os: [ubuntu-latest, windows-latest, macos-latest]
+          os: [ubuntu-20.04, ubuntu-18.04, windows-2022, macos-11, macos-12]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       uploadurl: ${{ steps.create_release.outputs.upload_url }}
     steps:

--- a/src/git.rs
+++ b/src/git.rs
@@ -313,7 +313,7 @@ impl RepoStatus {
     fn parse_digits_from_repo_status(status: &str) -> Result<i32, ConfigureError> {
         let digits = status
             .chars()
-            .filter(|c| c.is_digit(10))
+            .filter(|c| c.is_ascii_digit())
             .collect::<String>()
             .parse::<i32>()?;
 


### PR DESCRIPTION
Using an older version of Ubuntu allows us to use an older version of glibc, allowing compatibility with older versions of Linux