### PR TITLE
Update version to 0.6.4 and use publish task for Gradle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           cd gradle-plugin
           TAG_NAME=${GITHUB_REF#refs/tags/}
 
-          ./gradlew :configure:prepareToPublishToS3 --tag-name=$TAG_NAME :configure:publishPluginMavenPublicationToS3Repository
+          ./gradlew :configure:prepareToPublishToS3 --tag-name=$TAG_NAME :configure:release
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "configure"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "base64 0.13.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configure"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Jeremy Massel <jeremy.massel@automattic.com>"]
 edition = "2018"
 

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /// The plugin version number – change this to match whatever your tag will be
 group = "com.automattic.android"
-version = "0.6.3"
+version = "0.6.4"
 
 plugins {
     `kotlin-dsl`


### PR DESCRIPTION
Using `publishPluginMavenPublicationToS3Repository` Gradle task was not triggering `publishConfigurePluginMarkerMavenPublicationToS3Repository` which is necessary to publish the plugin marker artifacts. Instead of adding the `publishConfigurePluginMarkerMavenPublicationToS3Repository` to the task list, I decided to simply use the `publish` task, which is what we do in most repositories. I was originally concerned with `publish` task publishing other publications, so I wanted to use a specific task to future proof it. However, it's probably not something worth worrying about, so I think we should simplify the process.