### PR TITLE
Update version to 0.6.5 and fix the Gradle publish task name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
           cd gradle-plugin
           TAG_NAME=${GITHUB_REF#refs/tags/}
 
-          ./gradlew :configure:prepareToPublishToS3 --tag-name=$TAG_NAME :configure:release
+          ./gradlew :configure:prepareToPublishToS3 --tag-name=$TAG_NAME :configure:publish
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "configure"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "base64 0.13.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "configure"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["Jeremy Massel <jeremy.massel@automattic.com>"]
 edition = "2018"
 

--- a/gradle-plugin/configure/build.gradle.kts
+++ b/gradle-plugin/configure/build.gradle.kts
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /// The plugin version number – change this to match whatever your tag will be
 group = "com.automattic.android"
-version = "0.6.4"
+version = "0.6.5"
 
 plugins {
     `kotlin-dsl`


### PR DESCRIPTION
Fixes the task name from https://github.com/Automattic/configure/pull/27. The PR description explicitly says it needs to be `publish`, but apparently my hand has a mind of its own and typed `release` instead 🤦 